### PR TITLE
Fixed "Current need " in item drops page

### DIFF
--- a/front/scripts/controllers/item-drop-list.js
+++ b/front/scripts/controllers/item-drop-list.js
@@ -44,7 +44,7 @@ angular.module('tbsApp').controller('ItemDropListCtrl', function($scope, UserDat
                                 _stages : {},
                                 stages : [],
                                 needed : function() {
-                                    return (($scope.item_needed[this.ref] || 0) + (needed_rebirth.current[this.ref] || 0) + buddies.needed[this.ref] || 0) - ($scope.have_items[this.ref] || 0);
+                                    return (($scope.item_needed[this.ref] || 0) + (needed_rebirth.current[this.ref] || 0) + (buddies.needed[this.ref] || 0)) - ($scope.have_items[this.ref] || 0);
                                 }
                             };
                         }


### PR DESCRIPTION
The current implementation of needed() always returns 0 or negatives due to the operator precedence. So the parenthesis was added for fixing.
